### PR TITLE
Add support for `version_manifest_v2.json` parsing.

### DIFF
--- a/src/main/java/org/quiltmc/launchermeta/version_manifest/VersionEntry.java
+++ b/src/main/java/org/quiltmc/launchermeta/version_manifest/VersionEntry.java
@@ -15,19 +15,30 @@
  */
 package org.quiltmc.launchermeta.version_manifest;
 
+import java.util.Objects;
+import java.util.Optional;
+
 public class VersionEntry {
     private final String id;
     private final String type;
     private final String url;
     private final String time;
     private final String releaseTime;
+    private final String sha1;
+    private final int complianceLevel;
 
     public VersionEntry(String id, String type, String url, String time, String releaseTime) {
+        this(id, type, url, time, releaseTime, null, 0);
+    }
+
+    public VersionEntry(String id, String type, String url, String time, String releaseTime, String sha1, int complianceLevel) {
         this.id = id;
         this.type = type;
         this.url = url;
         this.time = time;
         this.releaseTime = releaseTime;
+        this.sha1 = sha1;
+        this.complianceLevel = complianceLevel;
     }
 
     public String getId() {
@@ -50,11 +61,19 @@ public class VersionEntry {
         return releaseTime;
     }
 
+    public Optional<String> getSha1() {
+        return Optional.ofNullable(sha1);
+    }
+
+    public int getComplianceLevel() {
+        return complianceLevel;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         VersionEntry versionEntry = (VersionEntry) o;
-        return id.equals(versionEntry.id) && type.equals(versionEntry.type) && url.equals(versionEntry.url) && time.equals(versionEntry.time) && releaseTime.equals(versionEntry.releaseTime);
+        return id.equals(versionEntry.id) && type.equals(versionEntry.type) && url.equals(versionEntry.url) && time.equals(versionEntry.time) && releaseTime.equals(versionEntry.releaseTime) && Objects.equals(sha1, versionEntry.sha1) && complianceLevel == versionEntry.complianceLevel;
     }
 }

--- a/src/main/java/org/quiltmc/launchermeta/version_manifest/VersionEntry.java
+++ b/src/main/java/org/quiltmc/launchermeta/version_manifest/VersionEntry.java
@@ -27,6 +27,7 @@ public class VersionEntry {
     private final String sha1;
     private final int complianceLevel;
 
+    @Deprecated
     public VersionEntry(String id, String type, String url, String time, String releaseTime) {
         this(id, type, url, time, releaseTime, null, 0);
     }

--- a/src/test/java/org/quiltmc/launchermeta/version_manifest/VersionManifestTest.java
+++ b/src/test/java/org/quiltmc/launchermeta/version_manifest/VersionManifestTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VersionManifestTest {
     public static final String MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
+    public static final String MANIFEST_URL_V2 = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
 
     private static final String TEST_JSON = """
             {
@@ -42,10 +43,36 @@ public class VersionManifestTest {
                 }]
             }
             """;
+    private static final String TEST_JSON_V2 = """
+            {
+                "latest": {
+                    "release": "1.17.1",
+                    "snapshot": "21w42a"
+                },
+                "versions": [{
+                    "id": "21w42a",
+                    "type": "snapshot",
+                    "url": "https://piston-meta.mojang.com/v1/packages/3ce8fdf60e69bfb0944e479ada4cf6b60dcc3995/21w42a.json",
+                    "time": "2021-10-20T12:46:24+00:00",
+                    "releaseTime": "2021-10-20T12:41:25+00:00",
+                    "sha1": "3ce8fdf60e69bfb0944e479ada4cf6b60dcc3995",
+                    "complianceLevel": 1
+                }]
+            }
+            """;
 
     @Test
     public void testParseFullJson() throws IOException {
         JsonElement json = TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL);
+        VersionManifest manifest = VersionManifest.fromJson(json);
+
+        assertEquals(manifest.getVersions().size(), json.getAsJsonObject().get("versions").getAsJsonArray().size(), "Size of version array matches json");
+        assertEquals(manifest.getLatestVersions().getRelease(), json.getAsJsonObject().get("latest").getAsJsonObject().get("release").getAsString(), "Size of version array matches json");
+    }
+
+    @Test
+    public void testParseFullJsonV2() throws IOException {
+        JsonElement json = TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL_V2);
         VersionManifest manifest = VersionManifest.fromJson(json);
 
         assertEquals(manifest.getVersions().size(), json.getAsJsonObject().get("versions").getAsJsonArray().size(), "Size of version array matches json");
@@ -62,8 +89,23 @@ public class VersionManifestTest {
     }
 
     @Test
+    public void testParseTestJsonV2() {
+        VersionManifest actual = VersionManifest.fromString(TEST_JSON_V2);
+        VersionManifest expected = new VersionManifest(new LatestVersions("1.17.1", "21w42a"),
+                List.of(new VersionEntry("21w42a", "snapshot", "https://piston-meta.mojang.com/v1/packages/3ce8fdf60e69bfb0944e479ada4cf6b60dcc3995/21w42a.json", "2021-10-20T12:46:24+00:00", "2021-10-20T12:41:25+00:00", "3ce8fdf60e69bfb0944e479ada4cf6b60dcc3995", 1)));
+
+        assertEquals(actual, expected, "Actual parse matches expected result");
+    }
+
+    @Test
     public void assertNoMethodReturnsAreNull() throws IOException {
         TestUtil.checkNoMethodsReturnNull(VersionManifest.class)
                 .accept(VersionManifest.fromJson(TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL)));
+    }
+
+    @Test
+    public void assertNoMethodReturnsAreNullV2() throws IOException {
+        TestUtil.checkNoMethodsReturnNull(VersionManifest.class)
+                .accept(VersionManifest.fromJson(TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL_V2)));
     }
 }

--- a/src/test/java/org/quiltmc/launchermeta/version_manifest/VersionManifestTest.java
+++ b/src/test/java/org/quiltmc/launchermeta/version_manifest/VersionManifestTest.java
@@ -17,12 +17,13 @@ package org.quiltmc.launchermeta.version_manifest;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import com.google.gson.JsonElement;
 import org.junit.jupiter.api.Test;
 import org.quiltmc.launchermeta.TestUtil;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VersionManifestTest {
     public static final String MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
@@ -63,23 +64,24 @@ public class VersionManifestTest {
 
     @Test
     public void testParseFullJson() throws IOException {
-        JsonElement json = TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL);
-        VersionManifest manifest = VersionManifest.fromJson(json);
-
-        assertEquals(manifest.getVersions().size(), json.getAsJsonObject().get("versions").getAsJsonArray().size(), "Size of version array matches json");
-        assertEquals(manifest.getLatestVersions().getRelease(), json.getAsJsonObject().get("latest").getAsJsonObject().get("release").getAsString(), "Size of version array matches json");
+        checkRemoteMatches(MANIFEST_URL, null);
     }
 
     @Test
     public void testParseFullJsonV2() throws IOException {
-        JsonElement json = TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL_V2);
-        VersionManifest manifest = VersionManifest.fromJson(json);
-
-        assertEquals(manifest.getVersions().size(), json.getAsJsonObject().get("versions").getAsJsonArray().size(), "Size of version array matches json");
-        assertEquals(manifest.getLatestVersions().getRelease(), json.getAsJsonObject().get("latest").getAsJsonObject().get("release").getAsString(), "Size of version array matches json");
+        checkRemoteMatches(MANIFEST_URL_V2, (json, manifest) -> {
+            String latestVersion = manifest.getLatestVersions().getRelease();
+            VersionEntry latestEntry = manifest.getVersions().stream()
+                    .filter(entry -> entry.getId().equals(latestVersion))
+                    .findFirst()
+                    .orElseThrow();
+            assertNotNull(latestEntry.getSha1(), "Latest version has a sha1");
+            assertNotEquals(latestEntry.getComplianceLevel(), 0, "Latest version has a compliance level");
+        });
     }
 
     @Test
+    @Deprecated
     public void testParseTestJson() {
         VersionManifest actual = VersionManifest.fromString(TEST_JSON);
         VersionManifest expected = new VersionManifest(new LatestVersions("1.17.1", "21w42a"),
@@ -99,13 +101,27 @@ public class VersionManifestTest {
 
     @Test
     public void assertNoMethodReturnsAreNull() throws IOException {
-        TestUtil.checkNoMethodsReturnNull(VersionManifest.class)
-                .accept(VersionManifest.fromJson(TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL)));
+        checkRemoteNoNulls(MANIFEST_URL);
     }
 
     @Test
     public void assertNoMethodReturnsAreNullV2() throws IOException {
+        checkRemoteNoNulls(MANIFEST_URL_V2);
+    }
+
+    private void checkRemoteMatches(String url, BiConsumer<JsonElement, VersionManifest> additional) throws IOException {
+        JsonElement json = TestUtil.getJsonFromURL(url);
+        VersionManifest manifest = VersionManifest.fromJson(json);
+
+        assertEquals(manifest.getVersions().size(), json.getAsJsonObject().get("versions").getAsJsonArray().size(), "Size of version array matches json");
+        assertEquals(manifest.getLatestVersions().getRelease(), json.getAsJsonObject().get("latest").getAsJsonObject().get("release").getAsString(), "Size of version array matches json");
+        if (additional != null) {
+            additional.accept(json, manifest);
+        }
+    }
+
+    private void checkRemoteNoNulls(String url) throws IOException {
         TestUtil.checkNoMethodsReturnNull(VersionManifest.class)
-                .accept(VersionManifest.fromJson(TestUtil.getJsonFromURL(VersionManifestTest.MANIFEST_URL_V2)));
+                .accept(VersionManifest.fromJson(TestUtil.getJsonFromURL(url)));
     }
 }


### PR DESCRIPTION
This adds the proper fields in `VersionEntry.java` as well as proper tests related to the new format.